### PR TITLE
Feat/chat/config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,11 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+
 }
 
 kotlin {

--- a/src/main/kotlin/com/example/nbe233team9/domain/chat/config/RedisConfig.kt
+++ b/src/main/kotlin/com/example/nbe233team9/domain/chat/config/RedisConfig.kt
@@ -1,0 +1,145 @@
+package com.example.nbe233team9.domain.chat.config
+
+import com.example.nbe233team9.domain.chat.service.RedisMessageSubscriber
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.messaging.simp.SimpMessagingTemplate
+
+
+@Configuration
+class RedisConfig (
+    private val objectMapper: ObjectMapper,
+    private val messagingTemplate: SimpMessagingTemplate
+){
+    // Redis 호스트 주소
+    @Value("\${spring.data.redis.host}")
+    private lateinit var redisHost: String
+
+    // Redis 포트 번호
+    @Value("\${spring.data.redis.port}")
+    private var redisPort: Int = 0
+
+    // Redis 비밀번호
+    @Value("\${spring.data.redis.password}")
+    private lateinit var redisPassword: String
+
+    // Redis Pub/Sub 채널 이름
+    @Value("\${redis.channel.topic}")
+    private lateinit var redisChannelTopic: String
+
+
+    /**
+     * RedisConnectionFactory
+     * - Redis와의 연결을 생성하는 팩토리
+     * - RedisStandaloneConfiguration을 사용하여 단일 노드 Redis 서버를 설정함
+     */
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val redisConfiguration = RedisStandaloneConfiguration().apply {
+            hostName = redisHost
+            port = redisPort
+            password = RedisPassword.of(redisPassword)
+        }
+        return LettuceConnectionFactory(redisConfiguration) // Lettuce 클라이언트를 사용한 연결 팩토리 생성
+    }
+
+
+    /**
+     * ChannelTopic
+     * - Redis Pub / Sub에서 사용할 채널 주제를 정의함
+     */    @Bean
+    fun topic(): ChannelTopic = ChannelTopic(redisChannelTopic)
+
+
+    /**
+     * RedisMessageListenerContainer
+     * - Redis Pub / Sub 메시지를 리스닝하는 컨테이너
+     * - 특정 채널 (topic)에 대해 메시지 리스너를 등록함
+     *
+     * @param connectionFactory Redis 연결 팩토리
+     * @param redisMessageSubscriberAdapter 메시지 리스너 어댑터
+     * @param topic Pub / Sub 채널 주제
+     */
+    @Bean
+    fun redisMessageListenerContainer(
+        connectionFactory: RedisConnectionFactory,
+        redisMessageSubscriberAdapter: MessageListenerAdapter,
+        topic: ChannelTopic
+    ): RedisMessageListenerContainer {
+        return RedisMessageListenerContainer().apply {
+            setConnectionFactory(connectionFactory)                  // Redis 연결 팩토리 설정
+            addMessageListener(redisMessageSubscriberAdapter, topic) // 메시지 리스너 등록
+        }
+    }
+
+
+    /**
+     * MessageListenerAdapter
+     * - Redis 메시지를 수신하여 처리하는 어댑터
+     * - 메시지를 처리할 `RedisMessageSubscriber`를 감싸는 역할
+     */
+    @Bean
+    fun redisMessageSubscriberAdapter(): MessageListenerAdapter {
+        // 메시지 구독자 생성 및 어댑터로 래핑
+        val redisMessageSubscriber = RedisMessageSubscriber(objectMapper, messagingTemplate)
+        return MessageListenerAdapter(redisMessageSubscriber, "handleMessage")
+    }
+
+
+    /**
+     * RedisTemplate (채팅 메시지용)
+     * - Redis에 채팅 메시지를 직렬화/역직렬화하여 저장 / 조회하기 위한 템플릿
+     *
+     * @param connectionFactory Redis 연결 팩토리
+     * @return RedisTemplate<String, Any>
+     */
+    @Bean(name = ["chatMessageRedisTemplate"])
+    fun chatMessageRedisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            setConnectionFactory(connectionFactory) // Redis 연결 팩토리 설정
+            keySerializer = StringRedisSerializer() // 키를 문자열로 직렬화
+            valueSerializer = Jackson2JsonRedisSerializer(Any::class.java) // 값을 JSON으로 직렬화
+        }
+    }
+
+
+    /**
+     * RedisTemplate (채팅방 데이터용)
+     * - Redis에 채팅방 데이터를 저장 / 조회하기 위한 템플릿
+     */
+    @Bean(name = ["chatRoomRedisTemplate"])
+    fun chatRoomRedisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            setConnectionFactory(connectionFactory) // Redis 연결 팩토리 설정
+            keySerializer = StringRedisSerializer() // 키를 문자열로 직렬화
+            valueSerializer = Jackson2JsonRedisSerializer(Any::class.java) // 값을 JSON으로 직렬화
+        }
+    }
+
+
+    /**
+     * RedisTemplate (범용)
+     * - Redis에 다양한 객체를 저장 / 조회하기 위한 범용 템플릿
+     */
+    @Bean(name = ["defaultRedisTemplate"])
+    fun defaultRedisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            setConnectionFactory(connectionFactory)
+            keySerializer = StringRedisSerializer()
+            valueSerializer = GenericJackson2JsonRedisSerializer()
+        }
+    }
+}

--- a/src/main/kotlin/com/example/nbe233team9/domain/chat/config/StompChannelInterceptor.kt
+++ b/src/main/kotlin/com/example/nbe233team9/domain/chat/config/StompChannelInterceptor.kt
@@ -1,0 +1,57 @@
+package com.example.nbe233team9.domain.chat.config
+
+import com.example.nbe233team9.domain.auth.security.JwtTokenProvider
+import lombok.RequiredArgsConstructor
+import lombok.extern.slf4j.Slf4j
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.messaging.support.MessageHeaderAccessor
+import org.springframework.stereotype.Component
+import java.security.Principal
+
+@Component
+@Slf4j
+class StompChannelInterceptor (
+    private val jwtTokenProvider: JwtTokenProvider
+) : ChannelInterceptor {
+
+    // 로거 객체 초기화
+    private val log = LoggerFactory.getLogger(StompChannelInterceptor::class.java)
+
+    // WebSocket 메시지가 전송되기 전에 실행됨
+    // JWT 토큰을 검증하고, 사용자 정보를 WebSocket 세션에 설정해줌
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? {
+
+        // StompHeaderAccessor 객체 생성 <- 메시지의 헤더 정보를 읽고 조작할 수 있도록
+        val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java) ?: return message
+
+        // WebSocket 요청의 명령어가 CONNECT면, JWT 검증을 수행함
+        val command = accessor.command
+        if(command == StompCommand.CONNECT) {
+
+            // 헤더에서 JWT 토큰을 추출함
+            var token = accessor.getFirstNativeHeader("Authorization")
+            if(!token.isNullOrBlank() && token.startsWith("Bearer ")) {
+                token = token.substring("Bearer ".length)
+            }
+
+            // JWT 토큰의 유효성을 검증함
+            if(token.isNullOrBlank() || !jwtTokenProvider.validateToken(token)) {
+                log.error("WebSocket 연결 실패: 유효하지 않은 JWT 토큰")
+                throw IllegalArgumentException("Invalid or missing JWT Token")
+            }
+
+            // 사용자 ID를 추출해서 WebSocket 세션에 저장함
+            val userId = jwtTokenProvider.getId(token).toString()
+            accessor.user = Principal { userId }
+
+            log.info("WebSocket 인증 성공: 사용자 ID = $userId")
+        }
+
+        return message
+    }
+}

--- a/src/main/kotlin/com/example/nbe233team9/domain/chat/config/StompChannelInterceptor.kt
+++ b/src/main/kotlin/com/example/nbe233team9/domain/chat/config/StompChannelInterceptor.kt
@@ -1,7 +1,6 @@
 package com.example.nbe233team9.domain.chat.config
 
 import com.example.nbe233team9.domain.auth.security.JwtTokenProvider
-import lombok.RequiredArgsConstructor
 import lombok.extern.slf4j.Slf4j
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.Message

--- a/src/main/kotlin/com/example/nbe233team9/domain/chat/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/example/nbe233team9/domain/chat/config/WebSocketConfig.kt
@@ -1,0 +1,29 @@
+package com.example.nbe233team9.domain.chat.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker // WebSocket 메시지 브로커 활성화
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+
+    // 클라이언트가 WebSocket 연결을 요청할 때 사용할 엔드포인트 설정
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/chat-socket")
+            .setAllowedOrigins("*")
+            .withSockJS()
+    }
+
+    // 메시지 브로커 설정
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.enableSimpleBroker("/topic/") // 클라이언트는 /topic/ 경로로 시작하는 주제를 구독하여 메시지를 받을 수 있음
+        registry.setApplicationDestinationPrefixes("/app")     // 클라이언트가 서버로 메시지를 송신할 때 사용하는 경로 (@MessageMapping으로 전달됨)
+    }
+
+    /* 기존에 있던 configureClientInboundChannel은
+     * 메시지 전송 시에는 jwt 검증을 안 하기로 해서 삭제
+    */
+}

--- a/src/main/kotlin/com/example/nbe233team9/domain/chat/service/RedisMessageSubscriber.kt
+++ b/src/main/kotlin/com/example/nbe233team9/domain/chat/service/RedisMessageSubscriber.kt
@@ -1,0 +1,11 @@
+package com.example.nbe233team9.domain.chat.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.messaging.simp.SimpMessagingTemplate
+
+class RedisMessageSubscriber (
+    private val objectMapper: ObjectMapper, // JSON 역직렬화
+    private val messagingTemplate: SimpMessagingTemplate // WebSocket 메시지 전송
+){
+
+}


### PR DESCRIPTION
## 📌 과제 설명
- 채팅에 필요한 config 파일들 추가했습니다.
<br>

## 👩‍💻 요구 사항과 구현 내용
- `RedisConfig` 먼저 추가해주기 위해서 `RedisMessageSubscriber`는 구현은 아직 안 하고, 생성만 해뒀습니다.
<br>

## ✅ 피드백 반영사항  
- 메시지 전송 시에는 JWT 검증을 안 하기로 했어서 기존 자바 코드에 있던 `configureClientInboundChannel` 메서드는 삭제했습니다.
